### PR TITLE
Fixed the selection of a value for language display. Anyone can properly utilize CRUD now.

### DIFF
--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -9,7 +9,7 @@ const formEvents = () => {
       const payload = {
         vocabName: document.querySelector('#termTitle').value,
         vocabDef: document.querySelector('#termDefinition').value,
-        languageId: document.querySelector('#select-language').value,
+        languageId: document.querySelector('#language_id').value,
         uid: ''
       };
 
@@ -27,7 +27,7 @@ const formEvents = () => {
       const payload = {
         vocabName: document.querySelector('#termTitle').value,
         vocabDef: document.querySelector('#termDefinition').value,
-        languageId: document.querySelector('#select-language').value,
+        languageId: document.querySelector('#language_id').value,
         uid: '',
         firebaseKey,
       };


### PR DESCRIPTION
I have changed the manner in which a form displays data by a user, and I did so by changing the id attached to the querySelector that is attached to value in the form. Now that this issue has been solved:

- Anyone can Create a term. 
- Anyone can Read(get) a term.
- Anyone can Update a term.
- Anyone can Delete a term.